### PR TITLE
Add tests for style_time helper

### DIFF
--- a/tests/testthat/test-style_time.R
+++ b/tests/testthat/test-style_time.R
@@ -1,0 +1,22 @@
+test_that("style_time formats numeric seconds", {
+  seconds <- c(0, 3661, 43200)
+  expect_equal(
+    style_time(seconds),
+    c("00:00", "01:01", "12:00")
+  )
+})
+
+test_that("style_time handles time-like objects", {
+  hms_times <- hms::as_hms(c(90, 3600))
+  difftimes <- as.difftime(c(120, 7200), units = "secs")
+  posix_times <- as.POSIXct("2024-01-01 03:45:30", tz = "UTC")
+
+  expect_equal(style_time(hms_times), c("00:01", "01:00"))
+  expect_equal(style_time(difftimes), c("00:02", "02:00"))
+  expect_equal(style_time(posix_times), "03:45")
+})
+
+test_that("style_time errors on unsupported input", {
+  expect_error(style_time("not a time"),
+               "x needs to be numeric, hms, difftime, POSIXct, or POSIXt")
+})


### PR DESCRIPTION
## Summary
- add testthat coverage for style_time formatting of numeric and time-like inputs
- verify unsupported inputs produce clear error message

## Testing
- ⚠️ `Rscript -e "devtools::test(filter = 'style_time')"` (fails: Rscript not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692854fc147c832782be391d2cc26b3f)