### PR TITLE
Fix histogram plotting for summary_table

### DIFF
--- a/R/summary_table.R
+++ b/R/summary_table.R
@@ -654,7 +654,12 @@ format_row_selection <- function(table_data, complete_day_label) {
 }
 
 histogram_plot <- function(values, name, color) {
-  values <- values |> purrr::flatten_dbl()
+  # Ensure values can be flattened whether they arrive as a vector or list
+  values <- values |>
+    (
+      \(x) if (is.list(x)) x else list(x)
+    )() |>
+    purrr::flatten_dbl()
 
   if (length(values) == 0 || all(is.na(values))) {
     return(ggplot2::ggplot())

--- a/tests/testthat/test-summary_table.R
+++ b/tests/testthat/test-summary_table.R
@@ -42,3 +42,19 @@ test_that("summary_table builds a gt table", {
   expect_equal(tbl$`_heading`$title, "Summary table")
   expect_true(stringr::str_detect(tbl$`_heading`$subtitle, "TZ:"))
 })
+
+test_that("summary_table creates histograms when requested", {
+  expect_no_error({
+    tbl <- summary_table(
+      sample.data.environment |> filter_Date(length = "2 days"),
+      coordinates = c(48.5, 9.1),
+      location = "Tuebingen",
+      site = "DE",
+      histograms = TRUE
+    )
+
+    # A histogram plot should be embedded for at least one row
+    data_rows <- gt::dt_data_get(tbl)
+    expect_true(any(purrr::map_lgl(data_rows$plot, inherits, "gg")))
+  })
+})


### PR DESCRIPTION
## Summary
- allow `histogram_plot()` to handle both list and vector inputs so histograms render
- add a regression test ensuring `summary_table()` produces histogram plots when requested

## Testing
- R -q -e "devtools::test(filter = 'summary_table')" *(fails: R is not available in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929bdaa9a9083278f6e100e6d1abaaa)