### PR TITLE
Veet import efficiency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,6 +27,7 @@ BugReports: https://github.com/tscnlab/LightLogR/issues
 Imports:
     circular,
     cowplot,
+    data.table,
     dplyr,
     ggplot2,
     ggsci,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # LightLogR 0.10.3
 
+* `VEET` import is more efficient by using `data.table` for modality-specific parsing and by avoiding expensive full-width TOF scans during duplicate checks and import overview plotting (@ThomasKraft, #85).
+
 * `LYS` import now works with any timestamp column in raw data, as long as it starts with `timestamp`
 
 # LightLogR 0.10.2

--- a/R/import_LL.R
+++ b/R/import_LL.R
@@ -419,11 +419,21 @@ imports <- function(device,
       # browser()
       #if there are duplicate rows, remove them and print an info message
       var_names <- names(data) |> setdiff("file.name")
-      duplicate.table <- 
-        data |>  
-        dplyr::add_count(dplyr::pick(dplyr::all_of(var_names)), name = "dupes") |> 
-        dplyr::filter(dupes > 1) |> 
-        dplyr::arrange(dplyr::desc(dupes))
+      duplicate_prefilter <-
+        data |>
+        dplyr::select(dplyr::all_of(intersect(c("Id", "Datetime"), var_names)))
+      possible_duplicate <-
+        duplicated(duplicate_prefilter) |
+        duplicated(duplicate_prefilter, fromLast = TRUE)
+      duplicate.table <-
+        if(any(possible_duplicate)) {
+          data[possible_duplicate, , drop = FALSE] |>
+            dplyr::add_count(dplyr::pick(dplyr::all_of(var_names)), name = "dupes") |>
+            dplyr::filter(dupes > 1) |>
+            dplyr::arrange(dplyr::desc(dupes))
+        } else {
+          data[0, , drop = FALSE]
+        }
       duplicates <- 
         duplicate.table |> 
         nrow()
@@ -462,7 +472,16 @@ imports <- function(device,
       
       #if autoplot is TRUE & silent is FALSE, make a plot
       if(auto.plot & !silent) {
-        data %>% gg_overview() %>% print()
+        plot.data <- data
+        plot.gap.data <- NULL
+        if(!!device == "VEET") {
+          import.dots <- rlang::list2(...)
+          if(identical(import.dots$modality, "TOF")) {
+            plot.data <- data |> dplyr::select(Id, Datetime)
+            plot.gap.data <- tibble::tibble()
+          }
+        }
+        plot.data %>% gg_overview(gap.data = plot.gap.data) %>% print()
       }
       #return the file
       data

--- a/R/import_expressions.R
+++ b/R/import_expressions.R
@@ -380,55 +380,70 @@ import_expr <- list(
                 Unit_ALS_Flicker = FALSE)
     }
     
-    data <- 
-      purrr::map(filename, \(filename) {
-        pattern <- paste0("^(?:[^,]*,){1}\\b", modality, "\\b")
-        
+    column_names <- names(veet_names[[modality]])
+    col_classes <- stats::setNames(
+      ifelse(veet_names[[modality]], "numeric", "character"),
+      column_names
+    )
+
+    data <- data.table::rbindlist(
+      lapply(filename, \(file_path) {
+        pattern <- paste0(
+          "^(?:[^,]*,){1}\\b",
+          modality,
+          "\\b"
+        )
+
         lines <- readr::read_lines(
-          file = filename, 
-          locale = locale, 
+          file = file_path,
+          locale = locale,
           n_max = n_max
         )
-        
-        lines <- lines[stringr::str_detect(lines, pattern)]
-        
-        if (length(lines) == 0) {
-          data <- tibble::as_tibble(
-            stats::setNames(
-              replicate(length(veet_names[[modality]]), character(), simplify = FALSE),
-              names(veet_names[[modality]])
+
+        lines <- lines[
+          stringr::str_detect(lines, pattern)
+        ]
+
+        result <-
+          if(length(lines) == 0) {
+            data.table::as.data.table(
+              stats::setNames(
+                lapply(col_classes, \(x) switch(
+                  x,
+                  "numeric" = numeric(),
+                  "character" = character()
+                )),
+                column_names
+              )
             )
-          )
-        } else {
-          data <- vroom::vroom(
-            I(paste(lines, collapse = "\n")),
-            delim = ",",
-            col_names = names(veet_names[[modality]]),
-            col_types = vroom::cols(.default = vroom::col_character()),
-            progress = FALSE,
-            altrep = FALSE
-          )
-        }
-        
-        data %>% 
-          dplyr::mutate(file.name = filename, .before = 1)
-      }) %>% 
-      purrr::list_rbind()
-    
-    data <- data %>% 
-      dplyr::mutate(
-        dplyr::across(
-          tidyselect::all_of(
-            veet_names[[modality]][veet_names[[modality]]] %>% names()
-          ), 
-          as.numeric
-        ),
-        Datetime = lubridate::with_tz(
-          lubridate::as_datetime(time_stamp, tz = "UTC"), 
-          tz
-        ), 
-        .before = 1
+          } else {
+            data.table::fread(
+              text = lines,
+              header = FALSE,
+              sep = ",",
+              col.names = column_names,
+              colClasses = unname(col_classes),
+              showProgress = FALSE
+            )
+          }
+
+        data.table::set(result, j = "file.name", value = file_path)
+        data.table::setcolorder(result, "file.name")
+
+        result
+      }),
+      use.names = TRUE
+    )
+
+    data.table::set(
+      data,
+      j = "Datetime",
+      value = lubridate::with_tz(
+        lubridate::as_datetime(data[["time_stamp"]], tz = "UTC"),
+        tz
       )
+    )
+    data.table::setcolorder(data, c("Datetime", setdiff(names(data), "Datetime")))
   }
   ),
   #GENEActiv GGIR

--- a/R/import_expressions.R
+++ b/R/import_expressions.R
@@ -388,48 +388,115 @@ import_expr <- list(
 
     data <- data.table::rbindlist(
       lapply(filename, \(file_path) {
-        pattern <- paste0(
-          "^(?:[^,]*,){1}\\b",
-          modality,
-          "\\b"
-        )
-
-        lines <- readr::read_lines(
-          file = file_path,
-          locale = locale,
-          n_max = n_max
-        )
-
-        lines <- lines[
-          stringr::str_detect(lines, pattern)
-        ]
-
-        result <-
-          if(length(lines) == 0) {
-            data.table::as.data.table(
-              stats::setNames(
-                lapply(col_classes, \(x) switch(
+        
+        con <- file(file_path, open = "r")
+        on.exit(close(con), add = TRUE)
+        
+        chunks <- list()
+        chunk_i <- 0L
+        n_imported <- 0L
+        
+        chunk_size <- 100000L
+        
+        repeat {
+          
+          lines <- readLines(
+            con,
+            n = chunk_size,
+            warn = FALSE
+          )
+          
+          if (!length(lines)) {
+            break
+          }
+          
+          # VEET modality is the second comma-separated field.
+          keep <- grepl(
+            paste0("^[^,]*,", modality, "(?:,|$)"),
+            lines,
+            perl = TRUE
+          )
+          
+          if (!any(keep)) {
+            next
+          }
+          
+          selected <- lines[keep]
+          
+          # Respect n_max as maximum number of records of the
+          # requested modality.
+          if (!is.infinite(n_max)) {
+            
+            remaining <- n_max - n_imported
+            
+            if (remaining <= 0L) {
+              break
+            }
+            
+            if (length(selected) > remaining) {
+              selected <- selected[seq_len(remaining)]
+            }
+          }
+          
+          chunk_i <- chunk_i + 1L
+          
+          chunks[[chunk_i]] <- data.table::fread(
+            text = selected,
+            header = FALSE,
+            sep = ",",
+            col.names = column_names,
+            colClasses = unname(col_classes),
+            showProgress = FALSE
+          )
+          
+          n_imported <- n_imported + length(selected)
+          
+          if (!is.infinite(n_max) && n_imported >= n_max) {
+            break
+          }
+        }
+        
+        close(con)
+        on.exit(NULL, add = FALSE)
+        
+        if (!length(chunks)) {
+          
+          result <- data.table::as.data.table(
+            stats::setNames(
+              lapply(
+                col_classes,
+                \(x) switch(
                   x,
                   "numeric" = numeric(),
                   "character" = character()
-                )),
-                column_names
-              )
+                )
+              ),
+              column_names
             )
-          } else {
-            data.table::fread(
-              text = lines,
-              header = FALSE,
-              sep = ",",
-              col.names = column_names,
-              colClasses = unname(col_classes),
-              showProgress = FALSE
-            )
-          }
-
-        data.table::set(result, j = "file.name", value = file_path)
-        data.table::setcolorder(result, "file.name")
-
+          )
+          
+        } else {
+          
+          result <- data.table::rbindlist(
+            chunks,
+            use.names = TRUE
+          )
+        }
+        
+        data.table::set(
+          result,
+          j = "file.name",
+          value = file_path
+        )
+        
+        data.table::setcolorder(
+          result,
+          c(
+            "file.name",
+            setdiff(names(result), "file.name")
+          )
+        )
+        
         result
       }),
       use.names = TRUE

--- a/R/import_expressions.R
+++ b/R/import_expressions.R
@@ -383,27 +383,51 @@ import_expr <- list(
     data <- 
       purrr::map(filename, \(filename) {
         pattern <- paste0("^(?:[^,]*,){1}\\b", modality, "\\b")
-        data <- 
-          readr::read_lines(file = filename, locale = locale, n_max = n_max)
-        data <- data[data %>% stringr::str_detect(pattern)]
-        data <- data |> 
-                  tibble::as_tibble() |> 
-                  tidyr::separate_wider_delim(value, 
-                                              ",", 
-                                              names = names(veet_names[[modality]])
-                                              )
-        data <- data %>% 
+        
+        lines <- readr::read_lines(
+          file = filename, 
+          locale = locale, 
+          n_max = n_max
+        )
+        
+        lines <- lines[stringr::str_detect(lines, pattern)]
+        
+        if (length(lines) == 0) {
+          data <- tibble::as_tibble(
+            stats::setNames(
+              replicate(length(veet_names[[modality]]), character(), simplify = FALSE),
+              names(veet_names[[modality]])
+            )
+          )
+        } else {
+          data <- vroom::vroom(
+            I(paste(lines, collapse = "\n")),
+            delim = ",",
+            col_names = names(veet_names[[modality]]),
+            col_types = vroom::cols(.default = vroom::col_character()),
+            progress = FALSE,
+            altrep = FALSE
+          )
+        }
+        
+        data %>% 
           dplyr::mutate(file.name = filename, .before = 1)
-        data
-      }) %>% purrr::list_rbind()
+      }) %>% 
+      purrr::list_rbind()
+    
     data <- data %>% 
       dplyr::mutate(
         dplyr::across(
           tidyselect::all_of(
-            veet_names[[modality]][veet_names[[modality]]] %>% names()), 
-        as.numeric),
+            veet_names[[modality]][veet_names[[modality]]] %>% names()
+          ), 
+          as.numeric
+        ),
         Datetime = lubridate::with_tz(
-          lubridate::as_datetime(time_stamp, tz = "UTC"), tz), .before = 1
+          lubridate::as_datetime(time_stamp, tz = "UTC"), 
+          tz
+        ), 
+        .before = 1
       )
   }
   ),

--- a/tests/testthat/test-import_LL.R
+++ b/tests/testthat/test-import_LL.R
@@ -74,7 +74,7 @@ test_that("VEET imports TOF with typed columns", {
   expect_equal(data$dist2_63, c(256, 257))
 })
 
-test_that("VEET TOF auto plot avoids expensive gap detection", {
+test_that("VEET TOF auto plot runs without errors", {
   filename <- tempfile(fileext = ".csv")
   writeLines(
     c(

--- a/tests/testthat/test-import_LL.R
+++ b/tests/testthat/test-import_LL.R
@@ -50,3 +50,54 @@ test_that("import works", {
   #check if the function extracted the correct name from the filepath and whether there is only one
   expect_equal(unique(data$Id) %>% as.character(), "205")
 })
+
+test_that("VEET imports TOF with typed columns", {
+  filename <- tempfile(fileext = ".csv")
+  writeLines(
+    c(
+      paste(c(1719835200, "TOF", seq_len(256)), collapse = ","),
+      paste(c(1719835260, "TOF", seq_len(256) + 1), collapse = ",")
+    ),
+    filename
+  )
+
+  data <- import$VEET(
+    filename,
+    modality = "TOF",
+    auto.plot = FALSE,
+    silent = TRUE
+  )
+
+  expect_equal(nrow(data), 2)
+  expect_true(is.numeric(data$time_stamp))
+  expect_true(is.numeric(data$conf1_0))
+  expect_equal(data$dist2_63, c(256, 257))
+})
+
+test_that("VEET TOF auto plot avoids expensive gap detection", {
+  filename <- tempfile(fileext = ".csv")
+  writeLines(
+    c(
+      paste(c(1719835200, "TOF", seq_len(256)), collapse = ","),
+      paste(c(1719835260, "TOF", seq_len(256) + 1), collapse = ",")
+    ),
+    filename
+  )
+
+  plot_file <- tempfile(fileext = ".pdf")
+  grDevices::pdf(plot_file)
+  on.exit(grDevices::dev.off(), add = TRUE)
+
+  data <- NULL
+  expect_output(
+    data <- import$VEET(
+      filename,
+      modality = "TOF",
+      auto.plot = TRUE,
+      silent = FALSE
+    ),
+    "Successfully read in"
+  )
+
+  expect_equal(nrow(data), 2)
+})


### PR DESCRIPTION
This PR stems from issue #85 and generally attempts to speed up and manage memory efficiency for VEET import, which can cause particular problems due to the large nature of data types such as TOF. Speed is improved here using the `data.table` package for import. There are also some relevant changes for auto.plot defaults when TOF data are imported to avoid unnecessary processing time. The basic testing code pasted below shows a general outcome I found of these changes cutting VEET import processing time by ~50%:

<img width="1043" height="103" alt="Screenshot 2026-07-20 at 14 06 11" src="https://github.com/user-attachments/assets/ac08d367-8807-4e88-a00d-b245921ea799" />


Ultimately I discovered that VEET files are large enough that the main memory issue occurs simply due to using `map:::purr()` on files that are of sufficient size to overwhelm a normal laptop when they are all loaded into memory. Packages such as GGIR manage this same type of issue by batch loading files and processing them into epochs in chunks before discarding the raw files during the process. Although something similar could be done here, the LightLogR infrastructure is sufficient for doing this manually with a short custom scripts (which is currently working well for me). So, I favor not introducing any changes for now.

Basic benchmarking code:

```
setwd(".")

cran_lib <- tempfile("cran-lib-")
local_lib <- tempfile("local-lib-")

dir.create(cran_lib)
dir.create(local_lib)

pkg <- "LightLogR"

# Install CRAN version into its own library
install.packages(
  pkg,
  lib = cran_lib,
  repos = "https://cloud.r-project.org",
  dependencies = TRUE
)

# Install your current local branch into its own library
install.packages(
  c("remotes", "pak"),
  repos = "https://cloud.r-project.org"
)

remotes::install_local(
  path = ".",
  lib = local_lib,
  dependencies = TRUE,
  upgrade = "never",
  force = TRUE
)

unload_lightlogr <- function() {
  if (paste0("package:", pkg) %in% search()) {
    detach(paste0("package:", pkg), unload = TRUE, character.only = TRUE)
  }
  
  if (pkg %in% loadedNamespaces()) {
    unloadNamespace(pkg)
  }
}

run_with_version <- function(lib, expr) {
  unload_lightlogr()
  library(pkg, lib.loc = lib, character.only = TRUE)
  force(expr)
}

filenames <- list.files(path = "PATH_TO_VEET_DATA/",
                        recursive = T, pattern = "Sensor_Data|sensor_data", full.names=TRUE)

microbenchmark::microbenchmark(
cran_time = {
  cran_result <- run_with_version(
    cran_lib,
    {
      LightLogR::import$VEET(
        filename = filenames[1:15],
        modality="TOF",
        auto.plot=F,
        silent=T
      )
    }
  )
},

local_time = {
  local_result <- run_with_version(
    local_lib,
    {
      LightLogR::import$VEET(
        filename = filenames[c(1:15)],
        modality="TOF",
        auto.plot=F,
        silent=T
      )
    }
  )
},
times = 2)
```